### PR TITLE
Fix comment typo in JBOwnableOverrides.sol

### DIFF
--- a/src/JBOwnableOverrides.sol
+++ b/src/JBOwnableOverrides.sol
@@ -16,7 +16,7 @@ import {JBOwner} from "./structs/JBOwner.sol";
 abstract contract JBOwnableOverrides is Context, JBPermissioned, IJBOwnable {
     //*********************************************************************//
     // --------------------------- custom errors --------------------------//
-    //*********************************************************************//b
+    //*********************************************************************//
 
     error JBOwnableOverrides_InvalidNewOwner();
 


### PR DESCRIPTION
Remove stray 'b' character from block comment separator.

# Description

*What does this PR: do, how, why?*

## Limitations & risks

*Are there any trade-off or new vulnarbility surface based on theses changes?*

# Check-list
- [ ] Tests are covering the new feature
- [ ] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [ ] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [ ] I have run the test locally (and they pass)
- [ ] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:

- Indirectly: