### PR TITLE
chore: v6 QC pass

### DIFF
--- a/src/JBOwnable.sol
+++ b/src/JBOwnable.sol
@@ -56,7 +56,8 @@ contract JBOwnable is JBOwnableOverrides {
     //*********************************************************************//
 
     /// @notice Either `newOwner` or `newProjectId` is non-zero or both are zero. But they can never both be non-zero.
-    /// @dev This function exists because some contracts will try to deploy contracts for a project before
+    /// @dev This function exists because some contracts need to deploy contracts for a project before the project's NFT
+    /// has been minted, so the transfer event resolves the project's current owner at emission time.
     function _emitTransferEvent(
         address previousOwner,
         address newOwner,

--- a/src/JBOwnableOverrides.sol
+++ b/src/JBOwnableOverrides.sol
@@ -16,7 +16,7 @@ import {JBOwner} from "./structs/JBOwner.sol";
 abstract contract JBOwnableOverrides is Context, JBPermissioned, IJBOwnable {
     //*********************************************************************//
     // --------------------------- custom errors --------------------------//
-    //*********************************************************************//b
+    //*********************************************************************//
 
     error JBOwnableOverrides_InvalidNewOwner();
 
@@ -45,7 +45,7 @@ abstract contract JBOwnableOverrides is Context, JBPermissioned, IJBOwnable {
     /// @dev The owner can give owner access to other addresses through the `permissions` contract.
     /// @param permissions A contract storing permissions.
     /// @param projects Mints ERC-721s that represent project ownership and transfers.
-    /// @param initialOwner The owner if the `intialProjectIdOwner` is 0 (until ownership is transferred).
+    /// @param initialOwner The owner if the `initialProjectIdOwner` is 0 (until ownership is transferred).
     /// @param initialProjectIdOwner The ID of the Juicebox project whose owner is this contract's owner (until
     /// ownership is transferred).
     constructor(
@@ -105,23 +105,22 @@ abstract contract JBOwnableOverrides is Context, JBPermissioned, IJBOwnable {
 
     /// @notice Gives up ownership of this contract, making it impossible to call `onlyOwner` and `_checkOwner`
     /// functions.
-    /// @notice This can only be called by the current owner.
+    /// @dev This can only be called by the current owner.
     function renounceOwnership() public virtual override {
         _checkOwner();
         _transferOwnership(address(0), 0);
     }
 
     /// @notice Sets the permission ID the owner can use to give other addresses owner access.
-    /// @notice This can only be called by the current owner.
+    /// @dev This can only be called by the current owner.
     /// @param permissionId The permission ID to use for `onlyOwner`.
     function setPermissionId(uint8 permissionId) public virtual override {
         _checkOwner();
         _setPermissionId(permissionId);
     }
 
-    /// @notice Transfers ownership of this contract to a new address (the `newOwner`). Can only be called by the
-    /// current owner.
-    /// @notice This can only be called by the current owner.
+    /// @notice Transfers ownership of this contract to a new address (the `newOwner`).
+    /// @dev This can only be called by the current owner.
     /// @param newOwner The address to transfer ownership to.
     function transferOwnership(address newOwner) public virtual override {
         _checkOwner();
@@ -133,8 +132,7 @@ abstract contract JBOwnableOverrides is Context, JBPermissioned, IJBOwnable {
     }
 
     /// @notice Transfer ownership of this contract to a new Juicebox project.
-    /// @notice This can only be called by the current owner.
-    /// @dev The `projectId` must fit within a `uint88`.
+    /// @dev This can only be called by the current owner. The `projectId` must fit within a `uint88`.
     /// @param projectId The ID of the project to transfer ownership to.
     function transferOwnershipToProject(uint256 projectId) public virtual override {
         _checkOwner();
@@ -150,7 +148,11 @@ abstract contract JBOwnableOverrides is Context, JBPermissioned, IJBOwnable {
     //*********************************************************************//
 
     /// @notice Either `newOwner` or `newProjectId` is non-zero or both are zero. But they can never both be non-zero.
-    /// @dev This function exists because some contracts will try to deploy contracts for a project before
+    /// @dev This function exists because some contracts need to deploy contracts for a project before the project's NFT
+    /// has been minted, so the transfer event resolves the project's current owner at emission time.
+    /// @param previousOwner The address of the previous owner.
+    /// @param newOwner The address of the new owner (zero if transferring to a project).
+    /// @param newProjectId The ID of the new owning project (zero if transferring to an address).
     function _emitTransferEvent(address previousOwner, address newOwner, uint88 newProjectId) internal virtual;
 
     /// @notice Sets the permission ID the owner can use to give other addresses owner access.

--- a/src/interfaces/IJBOwnable.sol
+++ b/src/interfaces/IJBOwnable.sol
@@ -7,12 +7,32 @@ interface IJBOwnable {
     event PermissionIdChanged(uint8 newId, address caller);
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner, address caller);
 
-    function PROJECTS() external view returns (IJBProjects);
-    function jbOwner() external view returns (address owner, uint88 projectOwner, uint8 permissionId);
-    function owner() external view returns (address);
+    /// @notice The contract that mints ERC-721s representing project ownership.
+    /// @return projects The `IJBProjects` contract.
+    function PROJECTS() external view returns (IJBProjects projects);
 
+    /// @notice This contract's owner information.
+    /// @return owner The owner address (used when `projectId` is 0).
+    /// @return projectId The ID of the Juicebox project whose owner is this contract's owner (0 if not project-owned).
+    /// @return permissionId The permission ID the owner can use to grant other addresses owner access.
+    function jbOwner() external view returns (address owner, uint88 projectId, uint8 permissionId);
+
+    /// @notice Returns the current owner's address.
+    /// @return owner The address of the current owner.
+    function owner() external view returns (address owner);
+
+    /// @notice Gives up ownership, making it impossible to call `onlyOwner` functions.
     function renounceOwnership() external;
+
+    /// @notice Sets the permission ID the owner can use to give other addresses owner access.
+    /// @param permissionId The permission ID to use for `onlyOwner`.
     function setPermissionId(uint8 permissionId) external;
+
+    /// @notice Transfers ownership of this contract to a new address.
+    /// @param newOwner The address to transfer ownership to.
     function transferOwnership(address newOwner) external;
+
+    /// @notice Transfers ownership of this contract to a Juicebox project.
+    /// @param projectId The ID of the project to transfer ownership to.
     function transferOwnershipToProject(uint256 projectId) external;
 }


### PR DESCRIPTION
## Summary
- Fix return param name `projectOwner` to `projectId` in `IJBOwnable.jbOwner()` to match `JBOwner` struct
- Complete truncated `@dev` comment on `_emitTransferEvent` in both `JBOwnable.sol` and `JBOwnableOverrides.sol`
- Remove stray `b` character from section separator in `JBOwnableOverrides.sol`
- Fix duplicate `@notice` tags (changed to `@dev` for access control notes) on `renounceOwnership`, `setPermissionId`, `transferOwnership`, `transferOwnershipToProject`
- Fix "intialProjectIdOwner" typo to "initialProjectIdOwner" in constructor NatSpec
- Add full NatSpec (`@notice`, `@param`, `@return`) to all functions in `IJBOwnable.sol`

## Test plan
- [ ] Verify no compilation errors
- [ ] Confirm interface matches implementation signatures

🤖 Generated with [Claude Code](https://claude.com/claude-code)