### PR TITLE
chore: standardize slither CI

### DIFF
--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   analyze:
     runs-on: ubuntu-latest
+    env:
+      NODE_ENV: production
     steps:
       - uses: actions/checkout@v4
         with:
@@ -19,7 +21,7 @@ jobs:
         with:
           node-version: latest
       - name: Install npm dependencies
-        run: npm ci
+        run: npm ci --production
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
       - name: Run slither


### PR DESCRIPTION
## Summary
- Standardize slither workflow (add `NODE_ENV: production`, `npm ci --production`)

## Test plan
- [x] `forge build` passes
- [ ] `forge test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)